### PR TITLE
Fix trailing whitespace in comment for submission details endpoint

### DIFF
--- a/src/routes/sales/invoices/e-invoices.js
+++ b/src/routes/sales/invoices/e-invoices.js
@@ -1020,7 +1020,7 @@ export default function (pool, config) {
     }
   });
 
-  // Fetch submission details by UUID and update missing longId
+  // Fetch submission details by UUID and update missing longId 
   router.get("/submission/:uuid", async (req, res) => {
     const { uuid } = req.params;
 


### PR DESCRIPTION
Remove unnecessary trailing whitespace in the comment for clarity.