### PR TITLE
Simplify comment for Create Invoice endpoint

### DIFF
--- a/src/routes/sales/invoices/invoices.js
+++ b/src/routes/sales/invoices/invoices.js
@@ -1672,7 +1672,7 @@ export default function (pool, config) {
     }
   });
 
-  // POST /api/invoices/submit - Create Invoice (Updated Schema, ID immutable after this)
+  // POST /api/invoices/submit - Create Invoice
   router.post("/submit", async (req, res) => {
     const client = await pool.connect();
     try {


### PR DESCRIPTION
Remove outdated schema reference from the comment for the Create Invoice endpoint to enhance clarity.