### PR TITLE
Allow custom_price to be a string or number for better input handling

### DIFF
--- a/src/pages/Catalogue/CustomerAddPage.tsx
+++ b/src/pages/Catalogue/CustomerAddPage.tsx
@@ -207,22 +207,22 @@ const CustomerAddPage: React.FC = () => {
         toast.error("Please select a product for all custom pricing rows.");
         return false;
       }
+
+      const priceValue =
+        typeof product.custom_price === "string"
+          ? parseFloat(product.custom_price)
+          : product.custom_price;
+
       if (
-        product.custom_price === undefined ||
-        product.custom_price === null ||
-        isNaN(Number(product.custom_price)) || // Check if it's a number or can be parsed
-        Number(product.custom_price) < 0
+        priceValue === undefined ||
+        priceValue === null ||
+        isNaN(priceValue) ||
+        priceValue < 0
       ) {
-        // Allow temporary string state like "12." during input, but validate final number
-        if (
-          typeof product.custom_price !== "string" ||
-          !String(product.custom_price).endsWith(".")
-        ) {
-          toast.error(
-            `Invalid custom price for product ID ${product.product_id}. Price must be a non-negative number.`
-          );
-          return false;
-        }
+        toast.error(
+          `Invalid custom price for product ID ${product.product_id}. Price must be a non-negative number.`
+        );
+        return false;
       }
     }
 

--- a/src/pages/Catalogue/CustomerFormPage.tsx
+++ b/src/pages/Catalogue/CustomerFormPage.tsx
@@ -362,11 +362,17 @@ const CustomerFormPage: React.FC = () => {
         toast.error("Please select a product for all custom pricing rows.");
         return false;
       }
+
+      const priceValue =
+        typeof product.custom_price === "string"
+          ? parseFloat(product.custom_price)
+          : product.custom_price;
+
       if (
-        product.custom_price === undefined ||
-        product.custom_price === null ||
-        isNaN(Number(product.custom_price)) ||
-        Number(product.custom_price) < 0
+        priceValue === undefined ||
+        priceValue === null ||
+        isNaN(priceValue) ||
+        priceValue < 0
       ) {
         toast.error(
           `Invalid custom price for product ID ${product.product_id}. Price must be a non-negative number.`
@@ -623,7 +629,7 @@ const CustomerFormPage: React.FC = () => {
   }
 
   return (
-    <div className="container mx-auto px-4 pb-4 -mt-36">
+    <div className="container mx-auto px-4 pb-4 -mt-24">
       <BackButton onClick={handleBackClick} className="mt-3 mb-2" />
       <div className="bg-white rounded-lg shadow-sm border border-default-200">
         <div className="p-6 border-b border-default-200">

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -387,7 +387,7 @@ export interface CustomProduct {
   customer_id: string;
   product_id: string;
   description?: string;
-  custom_price: number;
+  custom_price: number | string;
   is_available: boolean;
 }
 


### PR DESCRIPTION
Enable custom_price to accept both string and number types, improving the handling of intermediate input states and validation across components. This change enhances user experience by allowing more flexible input formats.