### PR TITLE
Restore original polling attempts and interval for invoice submission handler

### DIFF
--- a/src/utils/invoice/einvoice/EInvoiceSubmissionHandler.js
+++ b/src/utils/invoice/einvoice/EInvoiceSubmissionHandler.js
@@ -4,8 +4,8 @@ import { createHash } from "crypto";
 class EInvoiceSubmissionHandler {
   constructor(apiClient) {
     this.apiClient = apiClient;
-    this.MAX_POLLING_ATTEMPTS = 3; // 10 attempts (set to 3 for testing)
-    this.POLLING_INTERVAL = 100; // 5 seconds (set to 100 for testing)
+    this.MAX_POLLING_ATTEMPTS = 10; // 10 attempts (set to 3 for testing)
+    this.POLLING_INTERVAL = 5000; // 5 seconds (set to 100 for testing)
   }
 
   async submitAndPollDocuments(transformedInvoices) {


### PR DESCRIPTION
Revert the polling attempts and interval settings in the invoice submission handler to their original values for proper functionality.