### PR TITLE
Fix total calculations for 'OTH' products in LineItemsTable and InvoiceFormPage

### DIFF
--- a/src/components/Invoice/LineItemsTable.tsx
+++ b/src/components/Invoice/LineItemsTable.tsx
@@ -51,7 +51,12 @@ const LineItemsTable: React.FC<LineItemsTableProps> = ({
         const quantity = Number(item.quantity) || 0;
         const price = Number(item.price) || 0; // Will be negative for LESS items
         const tax = Number(item.tax) || 0; // Will be 0 for LESS items
-        item.total = (quantity * price + tax).toFixed(2);
+        // Special calculation for OTH products - use price only, not quantity * price
+        if (item.code === "OTH") {
+          item.total = (price + tax).toFixed(2);
+        } else {
+          item.total = (quantity * price + tax).toFixed(2);
+        }
       }
       newItems[index] = item;
       onItemsChange(newItems);

--- a/src/pages/Invoice/InvoiceFormPage.tsx
+++ b/src/pages/Invoice/InvoiceFormPage.tsx
@@ -296,8 +296,14 @@ const InvoiceFormPage: React.FC = () => {
     let taxTotal = 0;
     invoiceData.products.forEach((item) => {
       if (!item.issubtotal && !item.istotal) {
+      if (item.code === "OTH") {
+        // For 'OTH' products, use price directly as the line total, ignoring quantity.
+        subtotal += Number(item.price) || 0;
+      } else {
+        // For all other products, calculate total as quantity * price.
         subtotal += (Number(item.quantity) || 0) * (Number(item.price) || 0);
-        taxTotal += Number(item.tax) || 0;
+      }
+      taxTotal += Number(item.tax) || 0;
       }
     });
 


### PR DESCRIPTION
Adjust calculations to ensure 'OTH' products use price directly instead of quantity multiplied by price. This change improves accuracy in total calculations for invoices.