### PR TITLE
Clarify items type definition in LineItemsTableProps interface

### DIFF
--- a/src/components/Invoice/LineItemsTable.tsx
+++ b/src/components/Invoice/LineItemsTable.tsx
@@ -12,7 +12,7 @@ import {
 import { IconChevronDown, IconCheck } from "@tabler/icons-react";
 
 interface LineItemsTableProps {
-  items: ProductItem[]; // Still uses ProductItem for row data structure
+  items: ProductItem[];
   onItemsChange: (items: ProductItem[]) => void;
   customerProducts: CustomProduct[];
   productsCache: ProductItem[]; // Expect Product[] from cache hook


### PR DESCRIPTION
Update the `LineItemsTableProps` interface to enhance clarity regarding the type definition of `items`.