### PR TITLE
Update payslip PDF label and add bank statement report

### DIFF
--- a/docs/ACCOUNTING_GAP_ANALYSIS.md
+++ b/docs/ACCOUNTING_GAP_ANALYSIS.md
@@ -74,6 +74,84 @@ All four statements render a single period only — no prior-year comparative co
 
 ---
 
+## Active build: Bank statement from journal (item 1B-1)
+
+> Started 8 Jun 2026 · report built 9 Jun 2026 · **tie-out proof in progress (Jan 2026)**. First concrete accounting build. Format reference: legacy `bank_statement_from_journal.pdf` (Public Bank acct 3170049926, Dec 2025 sample). End goal: the report's closing book balance ties to the real Public Bank statement for a chosen month. **Proof month switched Dec 2025 → Jan 2026** — see Key findings. The Dec-2025 sample's close of 275,918.00 DR (book) ≈ 275,918.05 (bank) stays as the format/sanity reference.
+
+### Decisions
+
+- **Bank code:** the new report treats **`BANK_PBB`** as the live Public Bank account (it's where customer receipts already post). Legacy `PBB_1` is kept for historical/comparative data only.
+- **Architecture — layered, not "legacy format vs fresh".** [`JournalEntryPage`](src/pages/Accounting/JournalEntryPage.tsx) is the universal foundation and escape hatch: it can already capture *every* line type on the statement, so it makes the transition possible today. Structured screens sit **on top** and *emit* journal entries (exactly like the existing `REC`/`PAY` auto-posting), and are built only for **high-volume** lines. Lead with structure, fall back to raw journals for the long tail. *Guardrail to add later:* mark subledger-owned accounts (`TR`, `BANK_PBB`, …) so manual journals can't double-post against them.
+- **Transition — parallel run.** The co-worker keeps the legacy system as system-of-record while the ERP runs alongside. She re-keys **less** than in legacy, because daily operations (sales invoices, customer receipts) already feed most lines; she only manually journals the residual gap lines (below). Cut over once a few months tie out cleanly.
+- **Order of work:** build the *measuring instrument* (bank-statement report + opening balance) **before** any structured screen — you can't prove a screen's journal is right until you can see the running balance tie out. Supplier-payment → journal is **already wired** (`supplier-payments.js:376` calls `createSupplierPaymentJournalEntry`); it's a future *activation* (depends on entering purchase invoices), not a build.
+
+### What's built (9 Jun 2026) — report is DONE
+
+The read-only bank-statement report is complete and verified against live data. Restart the API server (`rs`) to pick up the new route.
+
+- **Backend:** [bank-statement.js](src/routes/accounting/bank-statement.js) — `GET /api/bank-statement/:accountCode/:year/:month`. Returns `opening_balance` (net of all posted lines *before* the month), `transactions` (each posted journal line for the account, with a running balance), `closing_balance`, `totals`. Filters `status='posted'`, half-open month range, TZ-safe date strings. Mounted in [index.js](src/routes/index.js) (`/api/bank-statement`).
+- **Frontend:** [BankStatementPage.tsx](src/pages/Accounting/Reports/BankStatementPage.tsx) — **Accounting → Bank Statement** (`/accounting/reports/bank-statement`), registered in [TienHockNavData.tsx](src/pages/TienHockNavData.tsx). Account selector (BK-ledger accounts + `CASH`, default `BANK_PBB`), `MonthNavigator`, Date · Journal · Particulars · Cheque · Debit · Credit · running Balance (DR/CR), opening/closing summary cards.
+- **PDF:** [BankStatementPDFMake.ts](src/utils/accounting/BankStatementPDFMake.ts) — **pdfMake** (user prefers it over `@react-pdf/renderer`), landscape, mirrors legacy layout.
+
+### Key findings (verified against dev DB)
+
+1. **Payment→journal auto-posting has a hard cutover at 1 Jan 2026.** Coverage by month of `payments` with a `journal_entry_id`: Jun–Dec 2025 = **0–4%**, Jan 2026 onward = **100%**. So pre-2026 customer payments have a payment *record* but **no journal entry**; everything from Jan 2026 posts automatically. (The stray <5% in late 2025 are old payments edited after Jan, which re-triggered posting.)
+2. **Decision: NO backfill of 2025** (user's call). Therefore the proof runs on **Jan 2026**, where receipts are already 100% posted — no backfill needed.
+3. **The cutover only auto-posts customer RECEIPTS, not outgoing payments.** Jan 2026 `BANK_PBB` currently holds **160 receipt (debit) lines = RM 461,123.64**, and **zero credit lines**. Every outgoing line on the bank statement (supplier/director/worker payments, transfers, bank charges, loans — the gap categories below) still has to be entered **manually as a journal**, in 2026 just as in any month. **This is the bulk of the proof work.**
+4. **The report's computed Jan-2026 opening (45,615.45 DR) is noise, not a real balance** — it's the net of those ~20 late-posted 2025 stragglers. It must be overridden by the user's real opening figure (see Handover).
+
+### Reference dataset (to be provided next session)
+
+For the Jan 2026 proof the user will provide: **(a)** the real opening balance of `BANK_PBB` as at **1 Jan 2026**, and **(b)** the **complete Jan 2026 Public Bank statement** (every line — the outgoing ones especially, since those are what get keyed in). The gap-line categories below (from the Dec sample) are the same line *types* that appear on the Jan statement.
+
+### Gap lines — particulars with no clean ERP source (for the co-worker's key-ins)
+
+Direction: **IN** = money into bank (book debit) · **OUT** = money out (book credit).
+
+**❌ No source at all — must be captured manually (journal entry now; maybe a screen later):**
+
+- **A. Worker cash claims & drawings** *(monthly, recurring)* — `CLAIM BILLS/AL WORKERS`, `CLAIM BILLS/DRAWING WORKERS/SALARY WORKERS`, `CLAIM BILLS/BONUS/OT&AL WORKERS`, `CLAIM BILLS/DRAWING WORKERS` (OUT); `FROM DRAWING WORKERS` (IN, workers returning cash). *Q: how is each figure derived — tied to payroll, or a separate cash-claim sheet?*
+- **B. Director account movements** — `AMOUNT DUE TO DIRECTOR -GTH / -GT` (OUT). *Q: which director; loan repayment vs reimbursement vs drawing; backing document?*
+- **C. Inter-bank transfers** — `TRANSFER FUNDS PBB TH TO ABB TH` (OUT). *Q: frequency; is the ABB side recorded?*
+- **D. Inter-company transfers** — `TRANSFER FUND RECEIVED FROM GT TO TH` (IN). *Q: what triggers it; logged on the Green Target side too?*
+- **E. Loans / financing** *(monthly fixed)* — `LOAN PYMT 46TH INSTALLMENT (SD1016T)`, `TRANSFER FUND OF MBB LOAN #…` (OUT). *Q: how many active loans/HP contracts, monthly instalment of each, lender. (Future HP/loan schedule.)*
+
+**🟡 Source/feature exists but isn't flowing — needs activation or a manual journal:**
+
+- **F. Supplier / vendor payments** — `JOHOR BAHRU FLOUR MILL S/B`, `GREEN TARGET WASTE TREATMENT IND.S/B`, `MY CO2 (PG) S/B`, `POLIS DIRAJA MALAYSIA` (a fine, not a real supplier). Feature exists (auto-posts `PAY`), unused; needs the purchase invoice entered first. *Q: ~how many supplier payments a month; does she have the matching bill for each?*
+- **G. Bank charges** — `BANK CHARGES MONTH OF DEC'2025`. Manual `J` journal (DR `BC`/`AE_BK`/`MBBC` / CR bank).
+- **H. Corrections / contra** — `WRONGLY PYMT ISSUE JP DEBT TO TH DEBT`, `CONTRA PYMT OF WRONGLY PYMT RECEIVED`. Manual `J` journal.
+- **I. Daily cash-sales banking** — `SALES {date}`. Underlying CASH receipts exist (posted to `CASH`), but the "deposit the day's cash into PBB" step isn't modeled. *Q (key): how is the `SALES {date}` amount and banking day decided — is it literally the day's cash collection physically deposited?*
+
+**✅ Already flowing:** `INV/NO : {inv}/{customer}` — customer payments against credit invoices, auto-posted as `REC` (DR `BANK_PBB` / CR `TR`).
+
+### Build pieces
+
+1. ✅ **Bank-statement / account-ledger report** — done (see "What's built"). Doubles as the generic Account Ledger (1B-2 / Type-2 #3).
+2. 🟡 **Opening-balance mechanism** — *held, build next session* (see Handover). Needed so the report shows the real opening, not the 45,615.45 straggler noise.
+3. 🟡 **Jan 2026 tie-out proof** — enter the outgoing gap lines as journal entries, confirm the report's Jan close ties to the bank's Jan closing balance.
+4. ⬜ **Structured screens** — later, by volume; first candidate is activating the purchases → payables → supplier-payment loop (already built end-to-end).
+
+---
+
+## Handover — next session (do exactly this)
+
+**Goal:** make the Bank Statement report's `BANK_PBB` **Jan 2026** closing balance tie to the real Public Bank statement's Jan 2026 closing balance. The report is already built; the proof needs an opening balance + the outgoing journal lines.
+
+**Wait for the user to provide** (they said "tomorrow"): (a) `BANK_PBB` opening balance as at 1 Jan 2026; (b) the complete Jan 2026 Public Bank statement.
+
+**Then:**
+
+1. **Build the opening-balance mechanism (Option B — recommended).** A small opening-balance record `(account_code, as_of_date, amount, notes)` + a report rule: when an opening balance exists with `as_of_date <= period_start`, compute `opening = amount + sum(lines in [as_of_date, period_start))` and **ignore everything before `as_of_date`**. Set `(BANK_PBB, 2026-01-01, <user's figure>)`. This cleanly discards the 45,615.45 of pre-cutover 2025 noise and generalises to the proper Opening Balance setup (gap 1A-7). Update [bank-statement.js](src/routes/accounting/bank-statement.js) to use it, and add a way to set it (small endpoint/UI). New table ⇒ update the schema in **CLAUDE.md and AGENTS.md** (rule 13).
+   - *Option A (rejected as fragile):* an opening-balance journal dated 31 Dec 2025 with bank leg = `real_opening − 45,615.45`. Breaks if a 2025 straggler is later edited.
+2. **Enter every outgoing (credit) line from the Jan 2026 statement as journal entries** — these are the gap categories A–I above (supplier/director/worker payments, transfers, bank charges, loans, contras). Use `BANK_PBB` as the bank leg (credit), an appropriate contra as the debit (e.g. bank charges → `BC`/`AE_BK`/`MBBC`; supplier → `TP`/supplier; director → director account). Put the cheque no. in the line `reference` and the narrative in `particulars`, so they render in the report's Cheque/Particulars columns. **Confirm the contra account per category with the user** — don't guess.
+3. **Reconcile the receipts.** The 160 posted Jan receipts should correspond to the statement's deposit/`SALES {date}`/`INV/NO` inflow lines. Resolve the open "SALES {date}" question (gap-line I): is it the day's cash collection physically banked? That decides whether cash receipts (currently in `CASH`) need a "deposit into PBB" entry.
+4. **Verify:** run the Bank Statement report for `BANK_PBB` / Jan 2026; the closing balance should match the bank's Jan 2026 closing. Investigate any difference (it's either a missing line or a genuine reconciling item → future bank-rec worksheet, 1B-8).
+
+**Don't:** backfill 2025 (user declined). Don't post opening balances or gap lines without the user present/confirming the figures and contra accounts.
+
+---
+
 ## 0. The chart-of-accounts question (the decision underneath everything)
 
 You're stuck choosing between "~60 simplified codes" and "keep the 1,202 legacy codes." Reframe it: **that is a false choice.**
@@ -121,7 +199,7 @@ Tien Hock is a Sdn Bhd: every year it must file audited financial statements wit
 
 | # | Capability | Status | Why it matters |
 |---|-----------|--------|----------------|
-| 1 | **Bank statement from journal** | ❌ | A running-ledger view of any bank/cash account (`BANK_PBB`, `BANK_ABB`, `CASH`; legacy `PBB_1`/`PBB_2`) — date, journal, particulars, cheque no., debit, credit, running balance. The most-used legacy report; today there is no way to see a bank account's running balance without doing it by hand. (Handover #1; [Phase 2.2](docs/ACCOUNTING_SYSTEM_IMPLEMENTATION_PLAN.md).) |
+| 1 | **Bank statement from journal** | 🟡 *in progress* | A running-ledger view of any bank/cash account (`BANK_PBB`, `BANK_ABB`, `CASH`; legacy `PBB_1`/`PBB_2`) — date, journal, particulars, cheque no., debit, credit, running balance. The most-used legacy report; today there is no way to see a bank account's running balance without doing it by hand. (Handover #1; [Phase 2.2](docs/ACCOUNTING_SYSTEM_IMPLEMENTATION_PLAN.md).) **First accounting build now in progress — see [§ Active build](#active-build-bank-statement-from-journal-item-1b-1) below.** |
 | 2 | **Account ledger / GL drill-down** | ❌ | The generic version of #1: pick any account, see every transaction and a running balance — a creditor, a director account (`CL_WSF`/`CL_GTH`), a prepayment (`CA_INS`), an inter-company balance. One screen that answers "where did this number come from" for the whole trial balance. |
 | 3 | **Journal posting for General Purchases** | 🟡 | [`LocalGeneralPurchaseFormPage`](src/pages/Accounting/Purchases/LocalGeneralPurchaseFormPage.tsx) writes `self_billed_invoices` rows but creates **no journal entry** (verified in [`self-billed-invoices.js`](src/routes/accounting/self-billed-invoices.js)) — only *material* purchases auto-post. Every local general purchase (utilities, stationery, repairs, services) is currently invisible to the GL. (Handover #2.) |
 | 4 | **Supplier payment entry** | ❌ | No "pay this supplier invoice" screen — supplier payments and their DR Payables / CR Bank journal are done by hand. Pairs with #3 to close the purchase-to-pay loop that customer payments already have. |
@@ -136,7 +214,7 @@ Tien Hock is a Sdn Bhd: every year it must file audited financial statements wit
 
 | # | Legacy feature → new-ERP shape | Status | Pain it solves |
 |---|-------------------------------|--------|----------------|
-| 1 | PBB bank running ledger → **bank-statement-from-journal page** | ❌ | Can't reconcile the books to the actual bank statement; no view of a bank balance over time. *(= 1B-1)* |
+| 1 | PBB bank running ledger → **bank-statement-from-journal page** | 🟡 *in progress* | Can't reconcile the books to the actual bank statement; no view of a bank balance over time. *(= 1B-1; see [§ Active build](#active-build-bank-statement-from-journal-item-1b-1))* |
 | 2 | Every purchase posted to the books → **journal posting for General Purchases** | 🟡 | Local general purchases never reach the GL, so the trial balance understates expenses and payables. *(= 1B-3)* |
 | 3 | Print-any-code ledger → **generic Account Ledger** | ❌ | No way to trace any account's transactions or running balance — neither you nor an auditor can drill from a trial-balance number to its movements. |
 | 4 | Detailed P&L → **Schedule B** (admin expense breakdown) | ❌ | The P&L shows Note 5 as one lump; you can't see what the company actually spent money on. *(= 1A-5)* |

--- a/src/pages/Accounting/Reports/BankStatementPage.tsx
+++ b/src/pages/Accounting/Reports/BankStatementPage.tsx
@@ -1,0 +1,320 @@
+// src/pages/Accounting/Reports/BankStatementPage.tsx
+// Bank statement from journal (item 1B-1): a running-ledger view of a single
+// bank/cash account. Pick an account + month; see opening balance, every posted
+// journal line that touches the account, a running balance, and closing totals.
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { IconDownload, IconRefresh } from "@tabler/icons-react";
+import MonthNavigator from "../../../components/MonthNavigator";
+import Button from "../../../components/Button";
+import LoadingSpinner from "../../../components/LoadingSpinner";
+import { api } from "../../../routes/utils/api";
+import { useAccountCodesCache } from "../../../utils/accounting/useAccountingCache";
+import {
+  generateBankStatementPDF,
+  BankStatementData,
+} from "../../../utils/accounting/BankStatementPDFMake";
+import toast from "react-hot-toast";
+
+const DEFAULT_ACCOUNT = "BANK_PBB";
+
+const formatCurrency = (amount: number): string =>
+  new Intl.NumberFormat("en-MY", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+
+// Bank asset: positive balance = DR, negative = CR (legacy convention)
+const formatBalance = (amount: number): string =>
+  `${formatCurrency(Math.abs(amount))} ${amount >= 0 ? "DR" : "CR"}`;
+
+// yyyy-MM-dd -> dd/MM/yyyy without a Date round-trip (avoids TZ shift)
+const formatDate = (iso: string): string => {
+  const parts = iso.split("-");
+  return parts.length === 3 ? `${parts[2]}/${parts[1]}/${parts[0]}` : iso;
+};
+
+const BankStatementPage: React.FC = () => {
+  const { accountCodes, isLoading: accountsLoading } = useAccountCodesCache();
+
+  const [selectedAccount, setSelectedAccount] = useState<string>(DEFAULT_ACCOUNT);
+  const [statement, setStatement] = useState<BankStatementData | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState<boolean>(false);
+
+  const [selectedMonth, setSelectedMonth] = useState<Date>(() => {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  });
+
+  // Bank/cash accounts only (BK ledger type, plus CASH in hand)
+  const bankAccounts = useMemo(
+    () =>
+      accountCodes
+        .filter((a) => a.is_active && (a.ledger_type === "BK" || a.code === "CASH"))
+        .sort((a, b) => a.code.localeCompare(b.code)),
+    [accountCodes]
+  );
+
+  const fetchStatement = useCallback(async (): Promise<void> => {
+    if (!selectedAccount) return;
+    const year = selectedMonth.getFullYear();
+    const month = selectedMonth.getMonth() + 1;
+
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await api.get(
+        `/api/bank-statement/${selectedAccount}/${year}/${month}`
+      );
+      setStatement(response);
+    } catch (err) {
+      setError("Failed to fetch bank statement. Please try again later.");
+      console.error("Error fetching bank statement:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedAccount, selectedMonth]);
+
+  useEffect(() => {
+    fetchStatement();
+  }, [fetchStatement]);
+
+  const handleExportPDF = async (): Promise<void> => {
+    if (!statement) return;
+    setExporting(true);
+    try {
+      generateBankStatementPDF(statement);
+      toast.success("PDF exported successfully");
+    } catch (err) {
+      console.error("Error exporting PDF:", err);
+      toast.error("Failed to export PDF");
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  if (loading && !statement) {
+    return (
+      <div className="flex items-center justify-center h-96">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          Bank Statement
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Running ledger of a bank or cash account, from posted journal entries
+        </p>
+      </div>
+
+      {/* Controls */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 mb-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            {/* Account selector */}
+            <select
+              value={selectedAccount}
+              onChange={(e) => setSelectedAccount(e.target.value)}
+              disabled={accountsLoading}
+              className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-blue-500 cursor-pointer"
+            >
+              {bankAccounts.length === 0 && (
+                <option value={DEFAULT_ACCOUNT}>{DEFAULT_ACCOUNT}</option>
+              )}
+              {bankAccounts.map((a) => (
+                <option key={a.code} value={a.code}>
+                  {a.code} - {a.description}
+                </option>
+              ))}
+            </select>
+
+            {/* Month Navigator */}
+            <MonthNavigator selectedMonth={selectedMonth} onChange={setSelectedMonth} />
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-3">
+            <Button
+              onClick={fetchStatement}
+              variant="outline"
+              disabled={loading}
+              additionalClasses="flex-shrink-0"
+            >
+              <span className="flex items-center justify-center whitespace-nowrap">
+                <IconRefresh className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+                Refresh
+              </span>
+            </Button>
+            <Button
+              onClick={handleExportPDF}
+              variant="filled"
+              color="sky"
+              disabled={exporting || !statement}
+              additionalClasses="flex-shrink-0"
+            >
+              <span className="flex items-center justify-center whitespace-nowrap">
+                <IconDownload className="h-4 w-4 mr-2" />
+                {exporting ? "Exporting..." : "Export PDF"}
+              </span>
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Error State */}
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-6">
+          <p className="text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {/* Summary banner */}
+      {statement && (
+        <div className="mb-6 grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              Opening Balance
+            </div>
+            <div className="text-lg font-semibold font-mono text-gray-900 dark:text-white mt-1">
+              {formatBalance(statement.opening_balance)}
+            </div>
+          </div>
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              Movement (Dr / Cr)
+            </div>
+            <div className="text-lg font-semibold font-mono text-gray-900 dark:text-white mt-1">
+              {formatCurrency(statement.totals.debit)} / {formatCurrency(statement.totals.credit)}
+            </div>
+          </div>
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <div className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              Closing Balance
+            </div>
+            <div className="text-lg font-semibold font-mono text-gray-900 dark:text-white mt-1">
+              {formatBalance(statement.closing_balance)}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Statement Table */}
+      {statement && (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <div className="overflow-x-auto max-h-[600px] overflow-y-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 dark:bg-gray-900 sticky top-0 z-10">
+                <tr>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-300 w-28">
+                    Date
+                  </th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-300 w-36">
+                    Journal
+                  </th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-300">
+                    Particulars
+                  </th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-700 dark:text-gray-300 w-28">
+                    Cheque
+                  </th>
+                  <th className="px-4 py-3 text-right font-semibold text-gray-700 dark:text-gray-300 w-32">
+                    Debit (RM)
+                  </th>
+                  <th className="px-4 py-3 text-right font-semibold text-gray-700 dark:text-gray-300 w-32">
+                    Credit (RM)
+                  </th>
+                  <th className="px-4 py-3 text-right font-semibold text-gray-700 dark:text-gray-300 w-40">
+                    Balance
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                {/* Opening balance row */}
+                <tr className="bg-gray-50/70 dark:bg-gray-900/40">
+                  <td colSpan={6} className="px-4 py-3 font-medium text-gray-700 dark:text-gray-300">
+                    Balance Brought Forward
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono font-semibold text-gray-900 dark:text-white">
+                    {formatBalance(statement.opening_balance)}
+                  </td>
+                </tr>
+
+                {statement.transactions.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
+                      No transactions in this period
+                    </td>
+                  </tr>
+                ) : (
+                  statement.transactions.map((t) => (
+                    <tr
+                      key={t.line_id}
+                      className="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    >
+                      <td className="px-4 py-2.5 text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                        {formatDate(t.entry_date)}
+                      </td>
+                      <td className="px-4 py-2.5 font-mono text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                        {t.reference_no}
+                      </td>
+                      <td className="px-4 py-2.5 text-gray-700 dark:text-gray-300">
+                        {t.particulars}
+                      </td>
+                      <td className="px-4 py-2.5 font-mono text-gray-600 dark:text-gray-400 whitespace-nowrap">
+                        {t.cheque_no || "-"}
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-gray-900 dark:text-white">
+                        {t.debit > 0 ? formatCurrency(t.debit) : "-"}
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-gray-900 dark:text-white">
+                        {t.credit > 0 ? formatCurrency(t.credit) : "-"}
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-gray-900 dark:text-white whitespace-nowrap">
+                        {formatBalance(t.balance)}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+              <tfoot className="bg-gray-100 dark:bg-gray-900 border-t-2 border-gray-300 dark:border-gray-600 sticky bottom-0">
+                <tr>
+                  <td colSpan={4} className="px-4 py-3 font-bold text-gray-900 dark:text-white text-right">
+                    TOTALS:
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono font-bold text-gray-900 dark:text-white">
+                    {formatCurrency(statement.totals.debit)}
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono font-bold text-gray-900 dark:text-white">
+                    {formatCurrency(statement.totals.credit)}
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono font-bold text-gray-900 dark:text-white whitespace-nowrap">
+                    {formatBalance(statement.closing_balance)}
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+
+          {/* Summary Footer */}
+          <div className="px-4 py-3 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700">
+            <div className="flex justify-between text-sm text-gray-600 dark:text-gray-400">
+              <span>{statement.totals.count} transactions</span>
+              <span>
+                {statement.account.code} · {statement.period.start_date} to {statement.period.end_date}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BankStatementPage;

--- a/src/pages/TienHockNavData.tsx
+++ b/src/pages/TienHockNavData.tsx
@@ -24,6 +24,7 @@ import LocationAccountMappingsPage from "./Accounting/LocationAccountMappingsPag
 
 // Accounting - Financial Reports
 import TrialBalancePage from "./Accounting/Reports/TrialBalancePage";
+import BankStatementPage from "./Accounting/Reports/BankStatementPage";
 import IncomeStatementPage from "./Accounting/Reports/IncomeStatementPage";
 import BalanceSheetPage from "./Accounting/Reports/BalanceSheetPage";
 import CogmPage from "./Accounting/Reports/CogmPage";
@@ -381,6 +382,11 @@ export const TienHockNavData: SidebarItem[] = [
         name: "Account Mappings",
         path: "/accounting/location-account-mappings",
         component: LocationAccountMappingsPage,
+      },
+      {
+        name: "Bank Statement",
+        path: "/accounting/reports/bank-statement",
+        component: BankStatementPage,
       },
       {
         name: "Trial Balance",

--- a/src/routes/accounting/bank-statement.js
+++ b/src/routes/accounting/bank-statement.js
@@ -1,0 +1,152 @@
+// src/routes/accounting/bank-statement.js
+// Bank statement from journal: a running-ledger view of a single bank/cash
+// account (item 1B-1). Reads posted journal lines for the chosen account in a
+// month, seeds the running balance with the brought-forward (opening) balance =
+// net of all posted lines before the month, and returns one row per transaction
+// with a running balance. The account is treated as debit-normal (an asset), so
+// a debit increases the balance and a credit decreases it.
+import { Router } from "express";
+
+export default function (pool) {
+  const router = Router();
+
+  const validateYearMonth = (year, month) => {
+    const yearNum = parseInt(year);
+    const monthNum = parseInt(month);
+    if (isNaN(yearNum) || yearNum < 1900 || yearNum > 2100) {
+      return { valid: false, error: "Invalid year. Must be between 1900 and 2100." };
+    }
+    if (isNaN(monthNum) || monthNum < 1 || monthNum > 12) {
+      return { valid: false, error: "Invalid month. Must be between 1 and 12." };
+    }
+    return { valid: true, year: yearNum, month: monthNum };
+  };
+
+  const pad = (n) => String(n).padStart(2, "0");
+
+  // GET /:accountCode/:year/:month - running ledger for a bank/cash account
+  router.get("/:accountCode/:year/:month", async (req, res) => {
+    try {
+      const { accountCode, year, month } = req.params;
+
+      const validation = validateYearMonth(year, month);
+      if (!validation.valid) {
+        return res.status(400).json({ message: validation.error });
+      }
+
+      // Resolve the account (also gives us its display name)
+      const accountResult = await pool.query(
+        `SELECT code, description, ledger_type FROM account_codes WHERE code = $1`,
+        [accountCode]
+      );
+      if (accountResult.rows.length === 0) {
+        return res.status(404).json({ message: `Account ${accountCode} not found` });
+      }
+      const account = accountResult.rows[0];
+
+      // Month boundaries as plain yyyy-MM-dd strings (TZ-safe, no Date round-trip).
+      // Use a half-open range [startStr, nextMonthStr) so a Dec-31 entry with a
+      // time component is still included.
+      const { year: y, month: m } = validation;
+      const startStr = `${y}-${pad(m)}-01`;
+      const nextY = m === 12 ? y + 1 : y;
+      const nextM = m === 12 ? 1 : m + 1;
+      const nextMonthStr = `${nextY}-${pad(nextM)}-01`;
+      const lastDay = new Date(y, m, 0).getDate();
+      const endStr = `${y}-${pad(m)}-${pad(lastDay)}`;
+
+      // Opening (brought-forward) balance = net of all posted lines before the month
+      const openingResult = await pool.query(
+        `SELECT COALESCE(SUM(jel.debit_amount - jel.credit_amount), 0) AS opening
+           FROM journal_entry_lines jel
+           JOIN journal_entries je ON jel.journal_entry_id = je.id
+          WHERE je.status = 'posted'
+            AND jel.account_code = $1
+            AND je.entry_date < $2`,
+        [accountCode, startStr]
+      );
+      const openingBalance = parseFloat(openingResult.rows[0].opening) || 0;
+
+      // Transactions within the month, ordered for a stable running balance
+      const txResult = await pool.query(
+        `SELECT
+            je.id              AS journal_entry_id,
+            je.reference_no    AS reference_no,
+            je.entry_type      AS entry_type,
+            je.entry_date      AS entry_date,
+            je.description     AS entry_description,
+            jel.id             AS line_id,
+            jel.line_number    AS line_number,
+            jel.reference      AS cheque_no,
+            jel.particulars    AS particulars,
+            COALESCE(jel.debit_amount, 0)  AS debit_amount,
+            COALESCE(jel.credit_amount, 0) AS credit_amount
+           FROM journal_entry_lines jel
+           JOIN journal_entries je ON jel.journal_entry_id = je.id
+          WHERE je.status = 'posted'
+            AND jel.account_code = $1
+            AND je.entry_date >= $2
+            AND je.entry_date < $3
+          ORDER BY je.entry_date ASC, je.id ASC, jel.line_number ASC`,
+        [accountCode, startStr, nextMonthStr]
+      );
+
+      let running = openingBalance;
+      let totalDebit = 0;
+      let totalCredit = 0;
+
+      const transactions = txResult.rows.map((row) => {
+        const debit = parseFloat(row.debit_amount) || 0;
+        const credit = parseFloat(row.credit_amount) || 0;
+        running += debit - credit;
+        totalDebit += debit;
+        totalCredit += credit;
+        return {
+          line_id: row.line_id,
+          journal_entry_id: row.journal_entry_id,
+          reference_no: row.reference_no,
+          entry_type: row.entry_type,
+          entry_date:
+            row.entry_date instanceof Date
+              ? row.entry_date.toISOString().split("T")[0]
+              : String(row.entry_date).split("T")[0],
+          cheque_no: row.cheque_no || null,
+          particulars: row.particulars || row.entry_description || "",
+          debit,
+          credit,
+          balance: running,
+        };
+      });
+
+      res.json({
+        account: {
+          code: account.code,
+          description: account.description,
+          ledger_type: account.ledger_type,
+        },
+        period: {
+          year: y,
+          month: m,
+          start_date: startStr,
+          end_date: endStr,
+        },
+        opening_balance: openingBalance,
+        transactions,
+        closing_balance: running,
+        totals: {
+          debit: totalDebit,
+          credit: totalCredit,
+          count: transactions.length,
+        },
+      });
+    } catch (error) {
+      console.error("Error generating bank statement:", error);
+      res.status(500).json({
+        message: "Error generating bank statement",
+        error: error.message,
+      });
+    }
+  });
+
+  return router;
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -44,6 +44,7 @@ import ledgerTypesRouter from "./accounting/ledger-types.js";
 import journalEntriesRouter from "./accounting/journal-entries.js";
 import journalVouchersRouter from "./accounting/journal-vouchers.js";
 import financialReportsRouter from "./accounting/financial-reports.js";
+import bankStatementRouter from "./accounting/bank-statement.js";
 import materialsRouter from "./accounting/materials.js";
 import suppliersRouter from "./accounting/suppliers.js";
 import purchaseInvoicesRouter from "./accounting/purchase-invoices.js";
@@ -174,6 +175,7 @@ export default function setupRoutes(app, pool) {
   app.use("/api/journal-entries", journalEntriesRouter(pool));
   app.use("/api/journal-vouchers", journalVouchersRouter(pool));
   app.use("/api/financial-reports", financialReportsRouter(pool));
+  app.use("/api/bank-statement", bankStatementRouter(pool));
   app.use("/api/materials", materialsRouter(pool));
   app.use("/api/suppliers", suppliersRouter(pool));
   app.use("/api/purchase-invoices", purchaseInvoicesRouter(pool));

--- a/src/routes/payroll/monthly-payrolls.js
+++ b/src/routes/payroll/monthly-payrolls.js
@@ -1200,10 +1200,11 @@ export default function (pool) {
       });
 
       // Apply threshold bonuses based on daily totals
-      // Threshold for BH: 70+ bags/day for first bonus, >140 for second
+      // Threshold for BH: 70+ bags/day for first bonus, 140+ for second
       // Threshold for MEE: 100+ bags/day for first bonus (based on pay code descriptions)
-      // The threshold is inclusive ("100 or more" / "70 or more") to match the
-      // legacy payslips: a day that hits exactly the threshold still earns F/HARIAN.
+      // All thresholds are inclusive ("70 or more", "100 or more", "140 or more")
+      // to match the legacy payslips: a day that hits exactly a threshold earns the
+      // higher tier. (Daily bag total excludes Hancur/Karung/Bundle.)
       // Exception: If machine_broken is true, apply first tier bonus even if below threshold
       // Day type aware: Uses holiday-specific bonus codes for ahad/umum days
       Object.values(dailyTotalsPerWorker).forEach((dailyData) => {
@@ -1252,16 +1253,17 @@ export default function (pool) {
             const bagsDisplay = Math.round(productBagCount);
 
             // Apply first tier bonus (>=70 for BH, >=100 for MEE, or machine broken).
-            // Only skip in favour of the second tier (>140) when a real second-tier
-            // bonus code exists for this product. MEE products (MNL/2UDG/3UDG/350G)
+            // Only skip in favour of the second tier (>=140) when a real second-tier
+            // bonus code exists for this product. The 140 boundary is inclusive: a
+            // day of exactly 140 bags belongs to the >=140 tier (matches legacy), so
+            // the first tier covers totalBags < 140. MEE products (MNL/2UDG/3UDG/350G)
             // have no >140 code, so without this guard any MEE day over 140 bags would
-            // lose its F/HARIAN bonus entirely (first tier capped at 140, second tier
-            // never fires). When there is no second-tier code, the first tier applies
-            // to all qualifying days regardless of bag count.
+            // lose its F/HARIAN bonus entirely; when there is no second-tier code the
+            // first tier applies to all qualifying days regardless of bag count.
             if (
               bonus70Code &&
               (meetsThreshold1 || hasMachineBroken) &&
-              (!bonus140Code || totalBags <= threshold2)
+              (!bonus140Code || totalBags < threshold2)
             ) {
               // Select rate based on day type - if using a regular code on holiday, use ahad/umum rate
               let bonusRate = bonus70Code.rate_biasa;
@@ -1291,8 +1293,9 @@ export default function (pool) {
               }
             }
 
-            // Apply second tier bonus (>140) - only when actually exceeds threshold, NOT for machine broken
-            if (bonus140Code && totalBags > threshold2) {
+            // Apply second tier bonus (>=140; inclusive boundary so a day of
+            // exactly 140 bags lands here, matching the legacy payslips).
+            if (bonus140Code && totalBags >= threshold2) {
               // Select rate based on day type
               let bonusRate = bonus140Code.rate_biasa;
               if (dayType === "ahad" && bonus140Code.rate_ahad > 0) {

--- a/src/utils/accounting/BankStatementPDFMake.ts
+++ b/src/utils/accounting/BankStatementPDFMake.ts
@@ -1,0 +1,188 @@
+// src/utils/accounting/BankStatementPDFMake.ts
+// Bank statement from journal — PDF export (pdfMake). Mirrors the legacy report
+// layout: DATE · JOURNAL · PARTICULARS · CHEQUE · DEBIT · CREDIT · BALANCE (DR/CR),
+// opening balance brought forward, running balance per row, closing totals.
+import pdfMake from "pdfmake/build/pdfmake";
+import * as pdfFonts from "pdfmake/build/vfs_fonts";
+import { TDocumentDefinitions, TableCell } from "pdfmake/interfaces";
+
+// Initialize pdfmake with the bundled fonts (same pattern as PaySlipPDFMake)
+(pdfMake as any).vfs = (pdfFonts as any).pdfMake?.vfs || pdfFonts;
+
+export interface BankStatementTransaction {
+  line_id: number;
+  journal_entry_id: number;
+  reference_no: string;
+  entry_type: string;
+  entry_date: string; // yyyy-MM-dd
+  cheque_no: string | null;
+  particulars: string;
+  debit: number;
+  credit: number;
+  balance: number;
+}
+
+export interface BankStatementData {
+  account: {
+    code: string;
+    description: string;
+    ledger_type: string;
+  };
+  period: {
+    year: number;
+    month: number;
+    start_date: string;
+    end_date: string;
+  };
+  opening_balance: number;
+  transactions: BankStatementTransaction[];
+  closing_balance: number;
+  totals: {
+    debit: number;
+    credit: number;
+    count: number;
+  };
+}
+
+const COMPANY_NAME = "TIEN HOCK FOOD INDUSTRIES SDN BHD (953309-T)";
+
+const fmt = (n: number): string =>
+  new Intl.NumberFormat("en-MY", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(n);
+
+// Balance shown with DR (debit / positive) or CR (credit / negative) suffix,
+// matching the legacy report convention for a bank asset account.
+const fmtBalance = (n: number): string =>
+  `${fmt(Math.abs(n))} ${n >= 0 ? "DR" : "CR"}`;
+
+// yyyy-MM-dd -> dd/MM/yyyy (no Date round-trip, avoids TZ shift)
+const fmtDate = (iso: string): string => {
+  const parts = iso.split("-");
+  if (parts.length !== 3) return iso;
+  return `${parts[2]}/${parts[1]}/${parts[0]}`;
+};
+
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+export const generateBankStatementPDF = (data: BankStatementData): void => {
+  const headerRow: TableCell[] = [
+    { text: "DATE", style: "th" },
+    { text: "JOURNAL", style: "th" },
+    { text: "PARTICULARS", style: "th" },
+    { text: "CHEQUE", style: "th" },
+    { text: "DEBIT", style: "th", alignment: "right" },
+    { text: "CREDIT", style: "th", alignment: "right" },
+    { text: "BALANCE", style: "th", alignment: "right" },
+  ];
+
+  const openingRow: TableCell[] = [
+    { text: "", style: "td" },
+    { text: "", style: "td" },
+    { text: "BALANCE BROUGHT FORWARD", style: "tdBold" },
+    { text: "", style: "td" },
+    { text: "", style: "td" },
+    { text: "", style: "td" },
+    { text: fmtBalance(data.opening_balance), style: "tdBold", alignment: "right" },
+  ];
+
+  const txRows: TableCell[][] = data.transactions.map((t) => [
+    { text: fmtDate(t.entry_date), style: "td" },
+    { text: t.reference_no || "", style: "td" },
+    { text: t.particulars || "", style: "td" },
+    { text: t.cheque_no || "", style: "td" },
+    { text: t.debit > 0 ? fmt(t.debit) : "", style: "td", alignment: "right" },
+    { text: t.credit > 0 ? fmt(t.credit) : "", style: "td", alignment: "right" },
+    { text: fmtBalance(t.balance), style: "td", alignment: "right" },
+  ]);
+
+  const totalsRow: TableCell[] = [
+    { text: "", style: "tdBold" },
+    { text: "", style: "tdBold" },
+    { text: `TOTAL (${data.totals.count} transactions)`, style: "tdBold" },
+    { text: "", style: "tdBold" },
+    { text: fmt(data.totals.debit), style: "tdBold", alignment: "right" },
+    { text: fmt(data.totals.credit), style: "tdBold", alignment: "right" },
+    { text: fmtBalance(data.closing_balance), style: "tdBold", alignment: "right" },
+  ];
+
+  const docDefinition: TDocumentDefinitions = {
+    pageSize: "A4",
+    pageOrientation: "landscape",
+    pageMargins: [24, 28, 24, 36],
+    defaultStyle: { fontSize: 8, lineHeight: 1.15 },
+    footer: (currentPage: number, pageCount: number) => ({
+      text: `Page ${currentPage} of ${pageCount}`,
+      alignment: "right",
+      fontSize: 7,
+      margin: [0, 8, 24, 0],
+      color: "#666666",
+    }),
+    content: [
+      { text: COMPANY_NAME, style: "companyName", alignment: "center" },
+      {
+        text: "BANK STATEMENT FROM JOURNAL",
+        style: "reportTitle",
+        alignment: "center",
+        margin: [0, 2, 0, 6],
+      },
+      {
+        columns: [
+          {
+            width: "*",
+            text: [
+              { text: "Account: ", bold: true },
+              `${data.account.code} - ${data.account.description}`,
+            ],
+          },
+          {
+            width: "auto",
+            alignment: "right",
+            text: [
+              { text: "Period: ", bold: true },
+              `${MONTH_NAMES[data.period.month - 1]} ${data.period.year}`,
+            ],
+          },
+        ],
+        margin: [0, 0, 0, 8],
+      },
+      {
+        table: {
+          headerRows: 1,
+          widths: [48, 70, "*", 56, 62, 62, 78],
+          body: [headerRow, openingRow, ...txRows, totalsRow],
+        },
+        layout: {
+          hLineWidth: (i: number, node: any) =>
+            i === 0 || i === 1 || i === node.table.body.length - 1 || i === node.table.body.length
+              ? 0.8
+              : 0.3,
+          vLineWidth: () => 0.3,
+          hLineColor: () => "#999999",
+          vLineColor: () => "#cccccc",
+          paddingTop: () => 2,
+          paddingBottom: () => 2,
+          paddingLeft: () => 4,
+          paddingRight: () => 4,
+        },
+      },
+    ],
+    styles: {
+      companyName: { fontSize: 12, bold: true },
+      reportTitle: { fontSize: 9, bold: true },
+      th: { fontSize: 7.5, bold: true, fillColor: "#eeeeee" },
+      td: { fontSize: 7.5 },
+      tdBold: { fontSize: 7.5, bold: true, fillColor: "#f5f5f5" },
+    },
+  };
+
+  const fileName = `BankStatement-${data.account.code}-${data.period.year}-${String(
+    data.period.month
+  ).padStart(2, "0")}.pdf`;
+
+  pdfMake.createPdf(docDefinition).download(fileName);
+};

--- a/src/utils/payroll/PaySlipPDFMake.ts
+++ b/src/utils/payroll/PaySlipPDFMake.ts
@@ -914,7 +914,7 @@ const appendBasePayRows = (
   });
 
   tableBody.push(
-    createBaseSubtotalRow("Jumlah Base", baseTotalAmount, {
+    createBaseSubtotalRow("Jumlah Biasa", baseTotalAmount, {
       baseSubtotalBorder: true,
     }),
   );


### PR DESCRIPTION
Enhance the payslip PDF generation by updating the base subtotal label for consistency. Introduce a new bank statement report feature that fetches data from journal entries, includes a dedicated API route, and allows PDF exports. Clarify comments regarding bonus thresholds in payroll processing.