### PR TITLE
Update Changelog and enhance salary report logic

### DIFF
--- a/src/components/ChangelogModal.tsx
+++ b/src/components/ChangelogModal.tsx
@@ -20,6 +20,11 @@ type ChangelogEntry = {
 const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: "2026-07-04",
+    ms: "Pembetulan Salary Report: bagi pekerja yang mempunyai lebih daripada satu ID kerja, cuti yang direkodkan di bawah satu ID tidak lagi menggugurkan gaji kerja harian ID lain pada hari yang sama daripada lajur GAJI. Angka laporan kini sepadan dengan gaji kasar dan slip gaji.",
+    en: "Salary Report fix: for staff with more than one job ID, leave recorded under one ID no longer removes the other ID's daily work pay for that day from the GAJI column. Report figures now match gross pay and the payslip.",
+  },
+  {
+    date: "2026-07-04",
     ms: "Laporan Bank Statement: PDF kini mempunyai reka bentuk baharu yang lebih kemas (kepala surat syarikat berlogo, ringkasan baki pembukaan/penutupan dan jadual yang lebih mudah dibaca). Butang eksport kini terus membuka paparan cetak dan bukannya memuat turun fail — pada telefon, PDF akan dibuka dalam tab baharu.",
     en: "Bank Statement report: the PDF has a refreshed, cleaner design (company letterhead with logo, opening/closing balance summary and an easier-to-read table). The export button now opens the print view directly instead of downloading the file — on phones, the PDF opens in a new tab.",
   },

--- a/src/routes/payroll/salary-report.js
+++ b/src/routes/payroll/salary-report.js
@@ -148,15 +148,15 @@ export default function (pool) {
           WHERE mp.year = $1 AND mp.month = $2
             -- Exclude daily work items dated on a leave day: they pay nothing as
             -- work (the day is paid via leave) and are excluded from gross_pay, so
-            -- the base/tambahan/overtime breakdown must drop them too. Matches by
-            -- staff name (siblings share leave) like the payslip filter.
+            -- the base/tambahan/overtime breakdown must drop them too. Scoped per
+            -- source_employee_id like removeLeaveDayWorkItems: leave under one
+            -- sibling ID must not drop another sibling job's work that day.
             AND NOT (
               pi.work_log_type = 'daily'
               AND pi.source_date IS NOT NULL
               AND EXISTS (
                 SELECT 1 FROM leave_records lr2
-                JOIN staffs s2 ON lr2.employee_id = s2.id
-                WHERE s2.name = (SELECT name FROM staffs WHERE id = ep.employee_id)
+                WHERE lr2.employee_id = pi.source_employee_id
                   AND lr2.status = 'approved'
                   AND lr2.company <> 'JP'
                   AND lr2.leave_date = pi.source_date
@@ -1275,8 +1275,7 @@ export default function (pool) {
               AND pi.source_date IS NOT NULL
               AND EXISTS (
                 SELECT 1 FROM leave_records lr2
-                JOIN staffs s2 ON lr2.employee_id = s2.id
-                WHERE s2.name = (SELECT name FROM staffs WHERE id = ep.employee_id)
+                WHERE lr2.employee_id = pi.source_employee_id
                   AND lr2.status = 'approved'
                   AND lr2.company <> 'JP'
                   AND lr2.leave_date = pi.source_date


### PR DESCRIPTION
Update the Changelog to include a fix for the Salary Report, ensuring that leave recorded under one job ID does not affect the pay of other job IDs on the same day. Enhance the salary report logic to accurately reflect gross pay and payslip figures.