### PR TITLE
Fix optional chaining for journal reference in PaymentCancellationErrorDialog

### DIFF
--- a/src/components/Invoice/PaymentCancellationErrorDialog.tsx
+++ b/src/components/Invoice/PaymentCancellationErrorDialog.tsx
@@ -51,7 +51,7 @@ const PaymentCancellationErrorDialog: React.FC<
                   onClick={() => onViewJournal(journalEntryId)}
                 >
                   View Journal
-                  {error.receipt_journal_reference_no
+                  {error?.receipt_journal_reference_no
                     ? ` ${error.receipt_journal_reference_no}`
                     : ""}
                 </Button>


### PR DESCRIPTION
Implement optional chaining to safely access the journal reference in the PaymentCancellationErrorDialog component.