### PR TITLE
Add changelog entry for Jelly Polly cash bill functionality

### DIFF
--- a/src/components/ChangelogModal.tsx
+++ b/src/components/ChangelogModal.tsx
@@ -19,6 +19,11 @@ type ChangelogEntry = {
 
 const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    date: "2026-07-25",
+    ms: "Jelly Polly: bil TUNAI kini boleh disimpan semula. Sebelum ini menyimpan bil tunai baharu gagal dengan mesej ralat, dan ralat yang sama juga berlaku semasa mengubah produk pada bil tunai sedia ada atau menukar invois kredit kepada tunai.",
+    en: "Jelly Polly: CASH bills can be saved again. Previously, saving a new cash bill failed with an error message, and the same error also occurred when editing the products on an existing cash bill or converting a credit invoice to cash.",
+  },
+  {
     date: "2026-07-24",
     ms: "Senarai dan butiran jurnal kini memaparkan nombor rujukan sebenar resit (contohnya T130726) — sama seperti yang dipaparkan pada penyata bank dan jurnal lama yang diimport — bukannya nombor dalaman REC-.... Carian jurnal juga kini menemui jurnal melalui nombor rujukan sebenar tersebut.",
     en: "The journal list and details now show the receipt's actual reference number (e.g. T130726) — matching what the bank statement and imported legacy journals already show — instead of the internal REC-... number. Journal search now also finds journals by that actual reference number.",

--- a/src/routes/jellypolly/invoices.js
+++ b/src/routes/jellypolly/invoices.js
@@ -983,7 +983,7 @@ export default function (pool, config) {
           INSERT INTO jellypolly.payments (
             invoice_id, payment_date, amount_paid, payment_method,
             payment_reference, notes, status, posting_date
-          ) VALUES ($1, $2, $3, $4, $5, $6, 'active', $2::date)
+          ) VALUES ($1, $2, $3, $4, $5, $6, 'active', $7)
         `;
         await client.query(paymentQuery, [
           createdInvoice.id,
@@ -992,6 +992,7 @@ export default function (pool, config) {
           paymentMethod, // Use provided payment method
           paymentReference, // Use provided reference
           paymentNotes, // Use provided notes or default
+          paymentDate, // posting_date (own parameter: date column, not timestamp)
         ]);
       }
 
@@ -1669,7 +1670,7 @@ export default function (pool, config) {
             INSERT INTO jellypolly.payments (
               invoice_id, payment_date, amount_paid, payment_method,
               payment_reference, notes, status, posting_date
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $2::date)
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             RETURNING payment_id
           `;
 
@@ -1681,6 +1682,7 @@ export default function (pool, config) {
               null,
               "Automatic payment - order details updated",
               "active",
+              automaticPaymentDate, // posting_date (own parameter: date column, not timestamp)
             ]);
 
             newPaymentCreated = true;
@@ -2014,7 +2016,7 @@ export default function (pool, config) {
         if (paymentAmount > 0) {
           const insertPaymentQuery = `
         INSERT INTO jellypolly.payments (invoice_id, payment_date, payment_method, amount_paid, notes, status, posting_date)
-        VALUES ($1, $2, 'cash', $3, 'Automatic payment - converted from INVOICE to CASH', 'active', $2::date)
+        VALUES ($1, $2, 'cash', $3, 'Automatic payment - converted from INVOICE to CASH', 'active', $4)
         RETURNING payment_id
       `;
 
@@ -2022,6 +2024,7 @@ export default function (pool, config) {
             id,
             paymentDate,
             paymentAmount,
+            paymentDate, // posting_date (own parameter: date column, not timestamp)
           ]);
 
           // Reduce customer credit usage by the settled outstanding amount


### PR DESCRIPTION
Introduce a changelog entry for the Jelly Polly cash bill feature, which resolves issues with saving new cash bills and editing existing ones. Update the payment insertion logic to correctly handle posting dates.