### PR TITLE
Remove unnecessary setPaymentJoinReceiptId calls in RentalDetailsPage

### DIFF
--- a/src/pages/GreenTarget/Rentals/RentalDetailsPage.tsx
+++ b/src/pages/GreenTarget/Rentals/RentalDetailsPage.tsx
@@ -336,7 +336,6 @@ const RentalDetailsPage: React.FC = () => {
     setPaymentMethod("cash");
     setPaymentInternalReference("");
     setPaymentReference("");
-    setPaymentJoinReceiptId(null);
     setIsLoadingCustomerRentals(true);
     // Preselect the customer's saved logical debtor identity when available;
     // the shared accounting block still displays where it posts in the GL.
@@ -1293,7 +1292,6 @@ const RentalDetailsPage: React.FC = () => {
                         setRecordPayment(
                           (current: boolean): boolean => !current
                         );
-                        setPaymentJoinReceiptId(null);
                       }}
                       className="flex items-center cursor-pointer group p-1"
                     >


### PR DESCRIPTION
Eliminate redundant calls to setPaymentJoinReceiptId in the RentalDetailsPage component to streamline the code.