### PR TITLE
Add print functionality for Stock Card and Production Summary

### DIFF
--- a/src/components/ChangelogModal.tsx
+++ b/src/components/ChangelogModal.tsx
@@ -20,6 +20,16 @@ type ChangelogEntry = {
 const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
     date: "2026-08-03",
+    ms: "Halaman Stock Movement kini mempunyai butang \"Print Stock Card\" untuk mencetak kad stok produk yang dipilih bagi bulan atau tempoh yang dipaparkan, dengan lajur B/F, PRODUCTION, ADJ/IN, RETURN, SOLD/OUT, DEFECT, FOC dan C/F serta baris jumlah — sama seperti kad stok yang dicetak sebelum ini. Lajur ADJ/IN dan DEFECT ialah nilai ADJ+ dan ADJ- yang dikunci masuk di halaman Stock Adjustments, manakala RETURN ialah kuantiti pulangan pada invois.",
+    en: "The Stock Movement page now has a \"Print Stock Card\" button that prints the selected product's stock card for the month or period on screen, with B/F, PRODUCTION, ADJ/IN, RETURN, SOLD/OUT, DEFECT, FOC and C/F columns plus a totals row — the same as the stock card printed before. The ADJ/IN and DEFECT columns are the ADJ+ and ADJ- amounts keyed on the Stock Adjustments page, and RETURN is the returned quantity on invoices.",
+  },
+  {
+    date: "2026-08-03",
+    ms: "Setiap halaman Production Records (Mee, Bihun, Bundle, SBH & SMEE, Empty Bag dan Jelly Polly) kini mempunyai butang \"Print Summary\" untuk mencetak ringkasan pengeluaran bulanan bagi halaman tersebut: satu baris bagi setiap produk berserta jumlah keseluruhan. Cetakan sentiasa meliputi semua produk halaman itu untuk tempoh yang dipilih, walaupun penapis produk atau kotak carian sedang digunakan.",
+    en: "Every Production Records page (Mee, Bihun, Bundle, SBH & SMEE, Empty Bag and Jelly Polly) now has a \"Print Summary\" button that prints that page's monthly production summary: one row per product with a grand total. The printout always covers all of that page's products for the selected period, even when the product filter or search box is in use.",
+  },
+  {
+    date: "2026-08-03",
     ms: "Slip gaji Green Target kini memaparkan bayaran cuti sebagai barisnya sendiri (contoh \"Cuti Tahunan - 1 Hari\") berserta \"Jumlah Cuti\", sama seperti Tien Hock dan Jelly Polly. Sebelum ini jumlah cuti hanya tersembunyi di dalam Jumlah Gaji Kasar apabila slip dicetak secara pukal dari halaman Payroll, jadi slip tidak boleh dikira semula. Halaman butiran gaji Green Target juga menambah jadual \"Leave Pay\" yang menyenaraikan setiap tarikh, jenis cuti, bilangan hari dan amaun. Tiada amaun gaji berubah.",
     en: "Green Target pay slips now show leave pay as its own line (e.g. \"Cuti Tahunan - 1 Hari\") with a \"Jumlah Cuti\" total, the same as Tien Hock and Jelly Polly. Previously the leave amount was only hidden inside Jumlah Gaji Kasar when slips were printed in bulk from the Payroll page, so the slip could not be added up. The Green Target payroll details page also gains a \"Leave Pay\" table listing each date, leave type, days and amount. No pay amounts change.",
   },

--- a/src/pages/Stock/ProductStockMovementPage.tsx
+++ b/src/pages/Stock/ProductStockMovementPage.tsx
@@ -18,8 +18,11 @@ import {
   IconX,
   IconStarFilled,
   IconArrowsSort,
+  IconPrinter,
 } from "@tabler/icons-react";
 import MonthNavigator from "../../components/MonthNavigator";
+import Button from "../../components/Button";
+import { generateStockCardPDF } from "../../utils/stock/StockCardPDF";
 import clsx from "clsx";
 import { isOthProductionProduct } from "../../config/othProductionProducts";
 import ProductOrderModal from "../../components/Catalogue/ProductOrderModal";
@@ -109,7 +112,9 @@ const ProductStockMovementPage: React.FC<ProductStockMovementPageProps> = ({
   const [monthlyTotals, setMonthlyTotals] = useState<
     StockMovementResponse["monthly_totals"] | null
   >(null);
+  const [productDescription, setProductDescription] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isPrinting, setIsPrinting] = useState(false);
 
   useScrollRestoration(
     `product-stock-movement:${storageScope}`,
@@ -264,11 +269,13 @@ const ProductStockMovementPage: React.FC<ProductStockMovementPageProps> = ({
       setInitialBalance(response.initial_balance || 0);
       setInitialBalanceDate(response.initial_balance_date || null);
       setMonthlyTotals(response.monthly_totals || null);
+      setProductDescription(response.product_description || "");
     } catch (error) {
       console.error("Error fetching stock movements:", error);
       toast.error("Failed to load stock movements");
       setMovements([]);
       setMonthlyTotals(null);
+      setProductDescription("");
     } finally {
       setIsLoading(false);
     }
@@ -338,14 +345,61 @@ const ProductStockMovementPage: React.FC<ProductStockMovementPageProps> = ({
     }
   };
 
+  // Print the legacy-style Stock Card for the selected product and period.
+  const canPrintStockCard: boolean =
+    !!selectedProductId && !!monthlyTotals && movements.length > 0;
+
+  const handlePrintStockCard = async (): Promise<void> => {
+    if (!selectedProductId || !monthlyTotals || movements.length === 0) return;
+
+    setIsPrinting(true);
+    try {
+      const month: string = String(selectedMonth.getMonth() + 1).padStart(
+        2,
+        "0"
+      );
+      const periodLabel: string =
+        viewType === "month"
+          ? `For the month of ${month}/${selectedMonth.getFullYear()}`
+          : `For the period ${formatDisplayDate(
+              dateRange.start
+            )} - ${formatDisplayDate(dateRange.end)}`;
+
+      await generateStockCardPDF({
+        productId: selectedProductId,
+        productDescription,
+        periodLabel,
+        showDayNumberOnly: viewType === "month",
+        movements,
+        totals: monthlyTotals,
+        closingBalance: movements[movements.length - 1]?.cf ?? 0,
+      });
+    } catch (error) {
+      console.error("Error printing stock card:", error);
+      toast.error("Gagal menjana PDF kad stok");
+    } finally {
+      setIsPrinting(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
       {/* Header */}
-      <div>
-        <h1 className="text-2xl font-bold text-default-900 dark:text-gray-100">Stock Movement</h1>
-        <p className="mt-1 text-sm text-default-500 dark:text-gray-400">
-          View daily stock movements and balances
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-default-900 dark:text-gray-100">Stock Movement</h1>
+          <p className="mt-1 text-sm text-default-500 dark:text-gray-400">
+            View daily stock movements and balances
+          </p>
+        </div>
+        <Button
+          onClick={handlePrintStockCard}
+          disabled={!canPrintStockCard || isLoading || isPrinting}
+          icon={IconPrinter}
+          variant="outline"
+        >
+          {isPrinting ? "Preparing..." : "Print Stock Card"}
+        </Button>
       </div>
 
       {/* Controls */}

--- a/src/pages/Stock/ProductionListPage.tsx
+++ b/src/pages/Stock/ProductionListPage.tsx
@@ -9,11 +9,21 @@ import {
   IconChevronsUp,
   IconEdit,
   IconPackage,
+  IconPrinter,
   IconSearch,
   IconX,
 } from "@tabler/icons-react";
 import clsx from "clsx";
 import TimeNavigator from "../../components/TimeNavigator";
+import Button from "../../components/Button";
+import {
+  generateProductionSummaryPDF,
+  ProductionSummaryRow,
+} from "../../utils/stock/ProductionSummaryPDF";
+import {
+  TIENHOCK_INFO,
+  JELLYPOLLY_INFO,
+} from "../../utils/invoice/einvoice/companyInfo";
 import ProductSelector from "../../components/Stock/ProductSelector";
 import ProductOrderModal from "../../components/Catalogue/ProductOrderModal";
 import { api } from "../../routes/utils/api";
@@ -301,6 +311,7 @@ const ProductionListPage: React.FC<ProductionListPageProps> = ({
     !isLoading && entries.length > 0
   );
   const [showProductOrderModal, setShowProductOrderModal] = useState(false);
+  const [isPrintingSummary, setIsPrintingSummary] = useState<boolean>(false);
   const [workerOrderByScope, setWorkerOrderByScope] = useState<
     Record<ProductionWorkerOrderScope, string[]>
   >({ BH_PACKING: [], MEE_PACKING: [], JP_PRODUCTION: [] });
@@ -690,6 +701,106 @@ const ProductionListPage: React.FC<ProductionListPageProps> = ({
     setSearchTerm("");
   };
 
+  // Monthly production summary print: one sheet for THIS page's product scope,
+  // covering the whole selected period. It deliberately ignores the product
+  // selector and search box so the printed sheet is always the full scope.
+  const summaryRows: ProductionSummaryRow[] = useMemo(() => {
+    const totalsByProduct: Map<string, ProductionSummaryRow> = new Map();
+
+    entries.forEach((entry: ProductionEntry): void => {
+      const existing: ProductionSummaryRow | undefined = totalsByProduct.get(
+        entry.product_id
+      );
+      // bags_packed is numeric(10,2), so it arrives from pg as a string.
+      const quantity: number = Number(entry.bags_packed) || 0;
+      if (existing) {
+        existing.quantity += quantity;
+        return;
+      }
+      totalsByProduct.set(entry.product_id, {
+        productId: entry.product_id,
+        description: entry.product_description || "",
+        quantity,
+      });
+    });
+
+    return Array.from(totalsByProduct.values()).sort(
+      (a: ProductionSummaryRow, b: ProductionSummaryRow): number => {
+        const aIndex: number =
+          productOrderIndex.get(a.productId) ?? Number.MAX_SAFE_INTEGER;
+        const bIndex: number =
+          productOrderIndex.get(b.productId) ?? Number.MAX_SAFE_INTEGER;
+        if (aIndex !== bIndex) return aIndex - bIndex;
+        return a.productId.localeCompare(b.productId);
+      }
+    );
+  }, [entries, productOrderIndex]);
+
+  const summaryTotal: number = useMemo(
+    () =>
+      summaryRows.reduce(
+        (total: number, row: ProductionSummaryRow): number =>
+          total + row.quantity,
+        0
+      ),
+    [summaryRows]
+  );
+
+  // "Bags" for packing products, "Pcs" for OTH stock; mixed scopes fall back
+  // to a neutral heading rather than mislabelling one of the units.
+  const summaryUnitLabel: string = useMemo(() => {
+    const units: Set<string> = new Set(
+      entries.map((entry: ProductionEntry): string => getUnitLabel(entry))
+    );
+    if (units.size !== 1) return "Quantity";
+    const [unit] = Array.from(units);
+    return unit.charAt(0).toUpperCase() + unit.slice(1);
+  }, [entries]);
+
+  const handlePrintSummary = async (): Promise<void> => {
+    setIsPrintingSummary(true);
+    try {
+      // "Mee Production Records" -> "Mee"; the default title yields "".
+      const scopeLabel: string = title
+        .replace(/\s*Production Records$/i, "")
+        .trim();
+      const reportTitle: string = (
+        viewMode === "month"
+          ? `Summary Monthly ${scopeLabel} Production`
+          : `Summary ${scopeLabel} Production`
+      ).replace(/\s{2,}/g, " ");
+
+      const periodLabel: string =
+        viewMode === "day"
+          ? `As at (${formatDateLocal(dateRange.start)
+              .split("-")
+              .reverse()
+              .join("/")})`
+          : viewMode === "year"
+          ? `As at (${selectedYear})`
+          : `As at (${String(selectedMonth.getMonth() + 1).padStart(
+              2,
+              "0"
+            )}/${selectedMonth.getFullYear()})`;
+
+      await generateProductionSummaryPDF({
+        companyName: apiBasePath.startsWith("/jellypolly")
+          ? JELLYPOLLY_INFO.name
+          : TIENHOCK_INFO.name,
+        reportTitle,
+        periodLabel,
+        unitLabel: summaryUnitLabel,
+        rows: summaryRows,
+        total: summaryTotal,
+      });
+    } catch (error) {
+      console.error("Error printing production summary:", error);
+      toast.error("Failed to generate production summary PDF");
+    } finally {
+      setIsPrintingSummary(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <div className="rounded-lg border border-default-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
@@ -721,6 +832,17 @@ const ProductionListPage: React.FC<ProductionListPageProps> = ({
               presets={false}
               size="sm"
             />
+            <Button
+              onClick={handlePrintSummary}
+              disabled={
+                isLoading || isPrintingSummary || summaryRows.length === 0
+              }
+              icon={IconPrinter}
+              variant="outline"
+              size="sm"
+            >
+              {isPrintingSummary ? "Preparing..." : "Print Summary"}
+            </Button>
           </div>
         </div>
 

--- a/src/utils/stock/ProductionSummaryPDF.tsx
+++ b/src/utils/stock/ProductionSummaryPDF.tsx
@@ -1,0 +1,240 @@
+// src/utils/stock/ProductionSummaryPDF.tsx
+// PDF printout of the monthly production summary, replacing the legacy
+// dot-matrix "SUMMARY MONTHLY MEE PRODUCTION AS AT (07/2026)" report.
+//
+// One sheet per Production Records page: the Mee page prints the MEE sheet,
+// the Bihun page the BIHUN sheet, and so on. Rows are the products that have
+// production entries in the selected period, in the shared product display
+// order, with a grand total. Content comes from the entries already loaded by
+// the page, never hardcoded.
+import React from "react";
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  StyleSheet,
+  pdf,
+  Image,
+} from "@react-pdf/renderer";
+import TienHockLogo from "../tienhock.png";
+import { printPdfBlob } from "../pdfPrintFallback";
+
+export interface ProductionSummaryRow {
+  productId: string;
+  description: string;
+  quantity: number;
+}
+
+export interface ProductionSummaryData {
+  companyName: string;
+  // e.g. "Summary Monthly Mee Production"
+  reportTitle: string;
+  // e.g. "As at (07/2026)"
+  periodLabel: string;
+  // Column heading for the quantity column: "Bags", "Pcs", or "Quantity" when
+  // the sheet mixes units.
+  unitLabel: string;
+  rows: ProductionSummaryRow[];
+  total: number;
+}
+
+const colors = {
+  textPrimary: "#111827",
+  textSecondary: "#374151",
+  textMuted: "#6B7280",
+  border: "#E5E7EB",
+  borderDark: "#9CA3AF",
+  zebra: "#F9FAFB",
+};
+
+const styles = StyleSheet.create({
+  page: {
+    paddingTop: 20,
+    paddingBottom: 40,
+    paddingLeft: 40,
+    paddingRight: 40,
+    fontFamily: "Helvetica",
+    fontSize: 9,
+    color: colors.textPrimary,
+  },
+  pageNumber: {
+    position: "absolute",
+    fontSize: 8,
+    bottom: 20,
+    left: 0,
+    right: 0,
+    textAlign: "center",
+    color: colors.textMuted,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 15,
+    gap: 12,
+  },
+  logo: {
+    width: 50,
+    height: 50,
+  },
+  headerTextContainer: {
+    flex: 1,
+  },
+  companyName: {
+    fontSize: 14,
+    fontFamily: "Helvetica-Bold",
+    color: colors.textPrimary,
+  },
+  reportTitle: {
+    fontSize: 12,
+    fontFamily: "Helvetica-Bold",
+    marginTop: 6,
+    color: colors.textSecondary,
+  },
+  periodText: {
+    fontSize: 9,
+    color: colors.textMuted,
+    marginTop: 3,
+  },
+  tableHeader: {
+    flexDirection: "row",
+    borderBottomWidth: 0.75,
+    borderBottomColor: colors.borderDark,
+    paddingVertical: 3,
+  },
+  th: {
+    fontSize: 7.5,
+    fontFamily: "Helvetica-Bold",
+    color: colors.textMuted,
+    textTransform: "uppercase",
+  },
+  tableRow: {
+    flexDirection: "row",
+    paddingVertical: 2.5,
+    borderBottomWidth: 0.25,
+    borderBottomColor: colors.border,
+  },
+  tableRowZebra: {
+    backgroundColor: colors.zebra,
+  },
+  totalRow: {
+    flexDirection: "row",
+    paddingVertical: 4,
+    marginTop: 2,
+    borderTopWidth: 0.75,
+    borderTopColor: colors.borderDark,
+    borderBottomWidth: 0.75,
+    borderBottomColor: colors.borderDark,
+  },
+  colCode: {
+    width: 110,
+    fontSize: 8.5,
+    fontFamily: "Courier",
+    color: colors.textSecondary,
+  },
+  colDesc: {
+    flex: 1,
+    fontSize: 8.5,
+    color: colors.textSecondary,
+    paddingRight: 6,
+  },
+  thQty: {
+    width: 90,
+    textAlign: "right",
+  },
+  colQty: {
+    width: 90,
+    textAlign: "right",
+    fontSize: 8.5,
+    fontFamily: "Courier",
+    color: colors.textSecondary,
+  },
+  colQtyBold: {
+    width: 90,
+    textAlign: "right",
+    fontSize: 9,
+    fontFamily: "Courier-Bold",
+    color: colors.textPrimary,
+  },
+  totalLabel: {
+    flex: 1,
+    fontSize: 9,
+    fontFamily: "Helvetica-Bold",
+    color: colors.textPrimary,
+  },
+  emptyText: {
+    marginTop: 10,
+    fontSize: 8.5,
+    color: colors.textMuted,
+  },
+});
+
+const formatQuantity = (value: number): string =>
+  new Intl.NumberFormat("en-MY", { maximumFractionDigits: 2 }).format(value);
+
+const ProductionSummaryPDFDocument: React.FC<{
+  data: ProductionSummaryData;
+}> = ({ data }) => (
+  <Document title={data.reportTitle} author={data.companyName}>
+    <Page size="A4" style={styles.page}>
+      <View style={styles.header}>
+        <Image src={TienHockLogo} style={styles.logo} />
+        <View style={styles.headerTextContainer}>
+          <Text style={styles.companyName}>{data.companyName}</Text>
+          <Text style={styles.reportTitle}>{data.reportTitle}</Text>
+          <Text style={styles.periodText}>{data.periodLabel}</Text>
+        </View>
+      </View>
+
+      <View style={styles.tableHeader} fixed>
+        <Text style={[styles.th, styles.colCode]}>Product</Text>
+        <Text style={[styles.th, styles.colDesc]}>Description</Text>
+        <Text style={[styles.th, styles.thQty]}>{data.unitLabel}</Text>
+      </View>
+
+      {data.rows.map((row: ProductionSummaryRow, index: number) => (
+        <View
+          key={row.productId}
+          style={
+            index % 2 === 1
+              ? [styles.tableRow, styles.tableRowZebra]
+              : styles.tableRow
+          }
+          wrap={false}
+        >
+          <Text style={styles.colCode}>{row.productId}</Text>
+          <Text style={styles.colDesc}>{row.description}</Text>
+          <Text style={styles.colQty}>{formatQuantity(row.quantity)}</Text>
+        </View>
+      ))}
+
+      {data.rows.length === 0 && (
+        <Text style={styles.emptyText}>
+          No production recorded for this period.
+        </Text>
+      )}
+
+      <View style={styles.totalRow} wrap={false}>
+        <Text style={styles.totalLabel}>Total</Text>
+        <Text style={styles.colQtyBold}>{formatQuantity(data.total)}</Text>
+      </View>
+
+      <Text
+        style={styles.pageNumber}
+        render={({ pageNumber, totalPages }) =>
+          `Page ${pageNumber} of ${totalPages}`
+        }
+        fixed
+      />
+    </Page>
+  </Document>
+);
+
+export const generateProductionSummaryPDF = async (
+  data: ProductionSummaryData
+): Promise<void> => {
+  const blob: Blob = await pdf(
+    <ProductionSummaryPDFDocument data={data} />
+  ).toBlob();
+  printPdfBlob(blob, "production summary PDF");
+};

--- a/src/utils/stock/StockCardPDF.tsx
+++ b/src/utils/stock/StockCardPDF.tsx
@@ -1,0 +1,271 @@
+// src/utils/stock/StockCardPDF.tsx
+// PDF printout of the per-product Stock Card, replacing the legacy dot-matrix
+// "STOCK CARD : <product> FOR THE MONTH OF MM/YYYY" report.
+//
+// Column mapping from the live Stock Movement data (confirmed with the user):
+//   ADJ/IN   <- adj_in    (ADJ+ keyed on the Stock Adjustments page)
+//   RETURN   <- returns   (returnproduct quantity on invoices)
+//   DEFECT   <- adj_out   (ADJ- / defect keyed on the Stock Adjustments page)
+// Content is 1:1 with the /api/stock/movements response, never hardcoded.
+import React from "react";
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  StyleSheet,
+  pdf,
+  Image,
+} from "@react-pdf/renderer";
+import TienHockLogo from "../tienhock.png";
+import { TIENHOCK_INFO } from "../invoice/einvoice/companyInfo";
+import { printPdfBlob } from "../pdfPrintFallback";
+import { StockMovement } from "../../types/types";
+
+export interface StockCardTotals {
+  production: number;
+  adj_in: number;
+  returns: number;
+  sold_out: number;
+  adj_out: number;
+  foc: number;
+}
+
+export interface StockCardData {
+  productId: string;
+  productDescription: string;
+  // "For the month of 07/2026" or "For the period 01/07/2026 - 31/07/2026"
+  periodLabel: string;
+  // Month view prints the bare day number like the legacy card; the rolling
+  // and custom views can span months, so they print DD/MM instead.
+  showDayNumberOnly: boolean;
+  movements: StockMovement[];
+  totals: StockCardTotals;
+  closingBalance: number;
+}
+
+const colors = {
+  textPrimary: "#111827",
+  textSecondary: "#374151",
+  textMuted: "#6B7280",
+  border: "#E5E7EB",
+  borderDark: "#9CA3AF",
+  zebra: "#F9FAFB",
+};
+
+const styles = StyleSheet.create({
+  page: {
+    paddingTop: 20,
+    paddingBottom: 40,
+    paddingLeft: 40,
+    paddingRight: 40,
+    fontFamily: "Helvetica",
+    fontSize: 9,
+    color: colors.textPrimary,
+  },
+  pageNumber: {
+    position: "absolute",
+    fontSize: 8,
+    bottom: 20,
+    left: 0,
+    right: 0,
+    textAlign: "center",
+    color: colors.textMuted,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 15,
+    gap: 12,
+  },
+  logo: {
+    width: 50,
+    height: 50,
+  },
+  headerTextContainer: {
+    flex: 1,
+  },
+  companyName: {
+    fontSize: 14,
+    fontFamily: "Helvetica-Bold",
+    color: colors.textPrimary,
+  },
+  reportTitle: {
+    fontSize: 12,
+    fontFamily: "Helvetica-Bold",
+    marginTop: 6,
+    color: colors.textSecondary,
+  },
+  periodText: {
+    fontSize: 9,
+    color: colors.textMuted,
+    marginTop: 3,
+  },
+  tableHeader: {
+    flexDirection: "row",
+    borderBottomWidth: 0.75,
+    borderBottomColor: colors.borderDark,
+    paddingVertical: 3,
+  },
+  th: {
+    fontSize: 7.5,
+    fontFamily: "Helvetica-Bold",
+    color: colors.textMuted,
+    textTransform: "uppercase",
+  },
+  tableRow: {
+    flexDirection: "row",
+    paddingVertical: 2,
+    borderBottomWidth: 0.25,
+    borderBottomColor: colors.border,
+  },
+  tableRowZebra: {
+    backgroundColor: colors.zebra,
+  },
+  totalRow: {
+    flexDirection: "row",
+    paddingVertical: 4,
+    marginTop: 2,
+    borderTopWidth: 0.75,
+    borderTopColor: colors.borderDark,
+    borderBottomWidth: 0.75,
+    borderBottomColor: colors.borderDark,
+  },
+  colDay: {
+    width: 46,
+    fontSize: 8.5,
+    fontFamily: "Courier",
+    color: colors.textSecondary,
+  },
+  col: {
+    flex: 1,
+    textAlign: "right",
+    fontSize: 8.5,
+    fontFamily: "Courier",
+    color: colors.textSecondary,
+  },
+  colBold: {
+    flex: 1,
+    textAlign: "right",
+    fontSize: 8.5,
+    fontFamily: "Courier-Bold",
+    color: colors.textPrimary,
+  },
+  thRight: {
+    textAlign: "right",
+  },
+  footNote: {
+    marginTop: 10,
+    fontSize: 7.5,
+    color: colors.textMuted,
+  },
+});
+
+// Zero prints as "0" exactly like the legacy card, which never blanks a cell.
+const formatNumber = (value: number): string =>
+  new Intl.NumberFormat("en-MY", { maximumFractionDigits: 0 }).format(value);
+
+const formatDayLabel = (
+  movement: StockMovement,
+  showDayNumberOnly: boolean
+): string => {
+  if (showDayNumberOnly) return String(movement.day);
+  // movement.date is already a plain local YYYY-MM-DD string from the API,
+  // so it is split directly rather than parsed through a Date.
+  const [, month, day] = movement.date.split("-");
+  return `${day}/${month}`;
+};
+
+const StockCardTableHeader: React.FC = () => (
+  <View style={styles.tableHeader} fixed>
+    <Text style={[styles.th, styles.colDay]}>Day</Text>
+    <Text style={[styles.th, styles.col, styles.thRight]}>B/F</Text>
+    <Text style={[styles.th, styles.col, styles.thRight]}>Production</Text>
+    <Text style={[styles.th, styles.col, styles.thRight]}>Adj/In</Text>
+    <Text style={[styles.th, styles.col, styles.thRight]}>Return</Text>
+    <Text style={[styles.th, styles.col, styles.thRight]}>Sold/Out</Text>
+    <Text style={[styles.th, styles.col, styles.thRight]}>Defect</Text>
+    <Text style={[styles.th, styles.col, styles.thRight]}>FOC</Text>
+    <Text style={[styles.th, styles.col, styles.thRight]}>C/F</Text>
+  </View>
+);
+
+const StockCardPDFDocument: React.FC<{ data: StockCardData }> = ({ data }) => (
+  <Document
+    title={`Stock Card ${data.productId}`}
+    author={TIENHOCK_INFO.name}
+  >
+    <Page size="A4" style={styles.page}>
+      <View style={styles.header}>
+        <Image src={TienHockLogo} style={styles.logo} />
+        <View style={styles.headerTextContainer}>
+          <Text style={styles.companyName}>{TIENHOCK_INFO.name}</Text>
+          <Text style={styles.reportTitle}>
+            Stock Card: {data.productId} ({data.productDescription})
+          </Text>
+          <Text style={styles.periodText}>{data.periodLabel}</Text>
+        </View>
+      </View>
+
+      <StockCardTableHeader />
+
+      {data.movements.map((movement: StockMovement, index: number) => (
+        <View
+          key={movement.date}
+          style={
+            index % 2 === 1
+              ? [styles.tableRow, styles.tableRowZebra]
+              : styles.tableRow
+          }
+          wrap={false}
+        >
+          <Text style={styles.colDay}>
+            {formatDayLabel(movement, data.showDayNumberOnly)}
+          </Text>
+          <Text style={styles.col}>{formatNumber(movement.bf)}</Text>
+          <Text style={styles.col}>{formatNumber(movement.production)}</Text>
+          <Text style={styles.col}>{formatNumber(movement.adj_in)}</Text>
+          <Text style={styles.col}>{formatNumber(movement.returns)}</Text>
+          <Text style={styles.col}>{formatNumber(movement.sold_out)}</Text>
+          <Text style={styles.col}>{formatNumber(movement.adj_out)}</Text>
+          <Text style={styles.col}>{formatNumber(movement.foc)}</Text>
+          <Text style={styles.colBold}>{formatNumber(movement.cf)}</Text>
+        </View>
+      ))}
+
+      <View style={styles.totalRow} wrap={false}>
+        <Text style={[styles.colDay, { fontFamily: "Helvetica-Bold" }]}>
+          Total
+        </Text>
+        <Text style={styles.col}>-</Text>
+        <Text style={styles.colBold}>{formatNumber(data.totals.production)}</Text>
+        <Text style={styles.colBold}>{formatNumber(data.totals.adj_in)}</Text>
+        <Text style={styles.colBold}>{formatNumber(data.totals.returns)}</Text>
+        <Text style={styles.colBold}>{formatNumber(data.totals.sold_out)}</Text>
+        <Text style={styles.colBold}>{formatNumber(data.totals.adj_out)}</Text>
+        <Text style={styles.colBold}>{formatNumber(data.totals.foc)}</Text>
+        <Text style={styles.colBold}>{formatNumber(data.closingBalance)}</Text>
+      </View>
+
+      <Text style={styles.footNote}>
+        ADJ/IN and DEFECT are the ADJ+ and ADJ- quantities keyed on the Stock
+        Adjustments page. RETURN is the returned quantity on invoices.
+      </Text>
+
+      <Text
+        style={styles.pageNumber}
+        render={({ pageNumber, totalPages }) =>
+          `Page ${pageNumber} of ${totalPages}`
+        }
+        fixed
+      />
+    </Page>
+  </Document>
+);
+
+export const generateStockCardPDF = async (
+  data: StockCardData
+): Promise<void> => {
+  const blob: Blob = await pdf(<StockCardPDFDocument data={data} />).toBlob();
+  printPdfBlob(blob, "stock card PDF");
+};


### PR DESCRIPTION
Introduce print buttons for the Stock Movement and Production Records pages, enabling users to generate PDF summaries for selected products and periods. This enhancement improves usability by allowing easy access to printed reports.